### PR TITLE
Add flag for showing the platform tour xblock in read only mode

### DIFF
--- a/platformtour/platformtour.py
+++ b/platformtour/platformtour.py
@@ -24,6 +24,8 @@ class PlatformTourXBlock(XBlock):
 
     loader = ResourceLoader(__name__)
 
+    show_in_read_only_mode = True
+
     display_name = String(
         display_name=('Display Name'),
         help=(


### PR DESCRIPTION
Made the platform tour xblock visible for specified students.

Tested locally on studio and lms, through adding the xblock to a course
and toggling view between staff and specified student.